### PR TITLE
Fix idle timer reset on tab activation

### DIFF
--- a/background.js
+++ b/background.js
@@ -202,7 +202,10 @@ chrome.storage.onChanged.addListener(async (changes, areaName) => {
 
 // タブの変更を監視
 chrome.tabs.onActivated.addListener(({ tabId }) => {
-  resetTabIdleTime(tabId);
+  // 既にタイマーが存在する場合はリセットしない
+  if (!tabIdleData.has(tabId)) {
+    resetTabIdleTime(tabId);
+  }
 });
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {

--- a/content.js
+++ b/content.js
@@ -41,15 +41,7 @@ activityEvents.forEach(eventType => {
   });
 });
 
-// ページの可視状態変更を監視
-document.addEventListener('visibilitychange', () => {
-  if (!document.hidden) {
-    reportActivity();
-  }
-});
-
-// フォーカス状態の変更を監視
-window.addEventListener('focus', reportActivity);
+// フォーカスやタブの可視状態の変化ではタイマーをリセットしない
 
 // ページロード完了時にアクティビティを報告
 if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- ensure the idle timer isn't reset when switching tabs
- remove focus-based timer reset in content script

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_6842153be2a883318f3637ee6ee9b448